### PR TITLE
Added g!file command, which reads from an attached text file and inte…

### DIFF
--- a/glolf/bot.py
+++ b/glolf/bot.py
@@ -1,3 +1,4 @@
+from file import parse_file_command
 import discord, dotenv
 config = dotenv.dotenv_values(".env")
 
@@ -108,6 +109,8 @@ async def handle_commands(message):
             return await message.channel.send(f"Glolf uses {prefix} as its prefix now! Try g" + message.content)
         if message.content.startswith(prefix.replace("g",'') + "tourney"):
             return await message.channel.send(f"Glolf uses {prefix} as its prefix now! Try g" + message.content)
+        if message.content.startswith(prefix.replace("g",'') + "file"):
+            return await message.channel.send(f"Glolf uses {prefix} as its prefix now! Try g" + message.content)
 
 
     if message.content.startswith(prefix + "glolfer"):
@@ -132,6 +135,13 @@ async def handle_commands(message):
         return await save_club(message, get_command_body(message, "createclub"), client=client)
     elif message.content.startswith(prefix + "viewclub"):
         return await view_club(message, get_command_body(message, "viewclub"))
+
+    elif message.content.startswith(prefix + "file"):
+        text = await parse_file_command(message, get_command_body(message, "file"))
+        message.content = text
+        message.attachments = []
+        return await handle_commands(message)
+
 
     elif message.content.startswith(prefix + "admincommands"):
         return await message.channel.send("!discordid, !addtempmodification, !updatecoming <true/false>, !clear_game_list, !forcequit, !countgames, !void")

--- a/glolf/file.py
+++ b/glolf/file.py
@@ -1,0 +1,24 @@
+import discord
+from os.path import splitext
+
+async def parse_file_command(message, command_body):
+    if len(message.attachments) == 0:
+        return await message.channel.send("Oops, you forgot to attach a text file containing your command")
+    elif len(message.attachments) != 1:
+        return await message.channel.send("Too many attachments!")
+    
+    attachment = message.attachments[0]
+
+    filename, fileExtension = splitext(attachment.filename)
+
+    if fileExtension != ".txt":
+        return await message.channel.send("I can only read .txt files")
+    
+    encoded_text = await attachment.read()
+    text = encoded_text.decode()
+
+    message.content = text
+    message.attachments = []
+    return text
+
+

--- a/glolf/tourneycommands.py
+++ b/glolf/tourneycommands.py
@@ -37,6 +37,22 @@ def biggest_power_of_two_less_than(n):
 def biggest_power_of_k_less_than(n, k=2):
     return k ** math.floor(math.log2(n)/math.log2(k))
 
+def abbreviate_contestant_list_message(contestants, template, char_limit = 2000):
+    num_contestants_used = 1
+    extra_string = f"... (and {len(contestants) - num_contestants_used} more)"
+    contestant_string = contestants[0]
+
+    for contestant in contestants[1:]:
+        if(len(template.format(contestant_string + ", " + contestant + f"... (and {len(contestants) - num_contestants_used - 1} more)")) <= char_limit):
+            num_contestants_used += 1
+            contestant_string = contestant_string + ", " + contestant
+            extra_string = f"... (and {len(contestants) - num_contestants_used} more)"
+            
+        else:
+            continue
+
+    return template.format(contestant_string + extra_string)
+
 async def tourney_series(message,
                 glolfer_names, 
                 wins_required=1,
@@ -152,7 +168,7 @@ async def battle_royale_glolftourney(message, glolfers_per_game=2, is_club_game=
         if(len(content) <= 4000):
             await message.channel.send(content)
         else:
-            await message.channel.send(f"{len(move_onto_next_round)} contestants (too many to fit in a discord message) randomly recieve byes and move onto the next round. Let's see who joins them!")
+            await message.channel.send(abbreviate_contestant_list_message(move_onto_next_round, "{} randomly recieve byes and move onto the next round. Let's see who joins them!"))
 
     # actual tourney time!
     round_num = 0
@@ -212,7 +228,7 @@ async def battle_royale_glolftourney(message, glolfers_per_game=2, is_club_game=
             if len(content) <= 4000:
                 await message.channel.send(content)
             else:
-                await message.channel.send(f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on (too many to fit in a discord message). Next round starts in five minutes...")
+                await message.channel.send(abbreviate_contestant_list_message(move_onto_next_round, f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on: " + "**{}** Next round starts in five minutes..."))
             if not debug:
                 await asyncio.sleep(60*4.5)
                 await message.channel.send(f"Next round starting in thirty seconds...")

--- a/glolf/tourneycommands.py
+++ b/glolf/tourneycommands.py
@@ -165,7 +165,7 @@ async def battle_royale_glolftourney(message, glolfers_per_game=2, is_club_game=
 
         print(len(competitors_this_round)/glolfers_per_game + len(move_onto_next_round))
         content = f"{', '.join(move_onto_next_round)} randomly recieve byes and move onto the next round. Let's see who joins them!"
-        if(len(content) <= 4000):
+        if(len(content) <= 2000):
             await message.channel.send(content)
         else:
             await message.channel.send(abbreviate_contestant_list_message(move_onto_next_round, "{} randomly recieve byes and move onto the next round. Let's see who joins them!"))
@@ -225,7 +225,7 @@ async def battle_royale_glolftourney(message, glolfers_per_game=2, is_club_game=
             if len(move_onto_next_round) == glolfers_per_game**2 and round_num != 1:
                 round_descriptor = "Nearfinals results:"
             content = f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on: **{', '.join(move_onto_next_round)}**. Next round starts in five minutes..."
-            if len(content) <= 4000:
+            if len(content) <= 2000:
                 await message.channel.send(content)
             else:
                 await message.channel.send(abbreviate_contestant_list_message(move_onto_next_round, f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on: " + "**{}** Next round starts in five minutes..."))

--- a/glolf/tourneycommands.py
+++ b/glolf/tourneycommands.py
@@ -148,7 +148,11 @@ async def battle_royale_glolftourney(message, glolfers_per_game=2, is_club_game=
         move_onto_next_round = glolfer_names[num_matches_required*glolfers_per_game:]
 
         print(len(competitors_this_round)/glolfers_per_game + len(move_onto_next_round))
-        await message.channel.send(f"{', '.join(move_onto_next_round)} randomly recieve byes and move onto the next round. Let's see who joins them!")
+        content = f"{', '.join(move_onto_next_round)} randomly recieve byes and move onto the next round. Let's see who joins them!"
+        if(len(content) <= 4000):
+            await message.channel.send(content)
+        else:
+            await message.channel.send(f"{len(move_onto_next_round)} contestants (too many to fit in a discord message) randomly recieve byes and move onto the next round. Let's see who joins them!")
 
     # actual tourney time!
     round_num = 0
@@ -204,8 +208,11 @@ async def battle_royale_glolftourney(message, glolfers_per_game=2, is_club_game=
                 round_descriptor = "Almostfinals results:"
             if len(move_onto_next_round) == glolfers_per_game**2 and round_num != 1:
                 round_descriptor = "Nearfinals results:"
-
-            await message.channel.send(f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on: **{', '.join(move_onto_next_round)}**. Next round starts in five minutes...")
+            content = f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on: **{', '.join(move_onto_next_round)}**. Next round starts in five minutes..."
+            if len(content) <= 4000:
+                await message.channel.send(content)
+            else:
+                await message.channel.send(f"**{round_descriptor}** {len(move_onto_next_round)} contestants move on (too many to fit in a discord message). Next round starts in five minutes...")
             if not debug:
                 await asyncio.sleep(60*4.5)
                 await message.channel.send(f"Next round starting in thirty seconds...")


### PR DESCRIPTION
Hello, I am @ben.hommrich#5744 on discord (I usually have my name as Pre Malone on blaseball servers).

I wanted to be able to make tournaments that are larger than the discord character limit can support, so I wrote a new command that allows you to attach a text file that will be read as a glolf command. As of right now the syntax is "g!file" in a message with an attached text file, but that can be changed if you wish. I added the logic to handle_commands to interpret this new command, as well as updating the old prefix messages to include this command. I placed the parsing function for this new command in file.py.

Additionally, the long lists of player names caused some tournament messages to be longer than the discord text limit, so I added some alternate messages that are used when the regular one is too long.

I tested this by starting a 2049 player tournament (accidental, but revealed the previously mentioned bug), in which the g!file command worked and the alternate messages I added were successful. I did not bother allowing the tournament to finish because that would have taken too long, but it appeared that it was working.